### PR TITLE
Update SageMath documentation URLs

### DIFF
--- a/README
+++ b/README
@@ -7,8 +7,8 @@ SageTeX is included with Sage, so to use it, you only need to make the
 file sagetex.sty known to TeX; that file will be in
 SAGE_ROOT/local/share/texmf/tex/latex/sagetex, along with
 documentation and examples. See the Sage installation guide at
-http://sagemath.org/doc/installation/ for complete instructions and
-http://sagemath.org/doc/tutorial/sagetex.html for a quick usage
+http://doc.sagemath.org/html/en/installation/ for complete instructions and
+http://doc.sagemath.org/html/en/tutorial/sagetex.html for a quick usage
 introduction. The complete documentation is in sagetex.pdf, in
 the SAGE_ROOT/... directory mentioned above.
 

--- a/example.tex
+++ b/example.tex
@@ -215,7 +215,7 @@ if you're using a recent version of \TeX Live, you can use its package
 manager to install those packages, or get them from CTAN:
 \href{http://www.ctan.org/pkg/tkz-berge}{\texttt{www.ctan.org/pkg/tkz-berge}}.
 See
-\href{http://sagemath.org/doc/reference/sage/graphs/graph_latex.html}{``\LaTeX{}
+\href{http://doc.sagemath.org/html/en/reference/sage/graphs/graph_latex.html}{``\LaTeX{}
   Options for Graphs''} in the Sage reference manual for more details.
 
 \begin{center}
@@ -287,7 +287,7 @@ if you're using a recent version of \TeX Live, you can use its package
 manager to install those packages, or get them from CTAN:
 \href{http://www.ctan.org/pkg/tkz-berge}{\texttt{www.ctan.org/pkg/tkz-berge}}.
 See
-\href{http://sagemath.org/doc/reference/sage/graphs/graph_latex.html}{``\LaTeX{}
+\href{http://doc.sagemath.org/html/en/reference/sage/graphs/graph_latex.html}{``\LaTeX{}
   Options for Graphs''} in the Sage reference manual for more details.
 
 \begin{center}

--- a/py-and-sty.dtx
+++ b/py-and-sty.dtx
@@ -958,7 +958,7 @@ class SageTeXProcessor():
 is being processed by sagetex.py version "{2}".
 Please make sure that TeX is using the sagetex.sty 
 from your current version of Sage; see
-http://www.sagemath.org/doc/installation/sagetex.html.""".format(jobname,
+http://doc.sagemath.org/html/en/tutorial/sagetex.html.""".format(jobname,
   version, pyversion)
       if version_check:
         raise VersionError, errstr

--- a/sagetex.dtx
+++ b/sagetex.dtx
@@ -297,7 +297,7 @@ suggestions.
 % version 4.3.1, \ST comes included with Sage, so you only need to make
 % \texttt{sagetex.sty}, the \LTX package, known to \TeX. Full details of
 % this are in the Sage Installation guide at
-% \href{http://sagemath.org/doc/installation/}{\texttt{sagemath.org/doc/installation/}}
+% \href{http://doc.sagemath.org/html/en/installation/}{\texttt{doc.sagemath.org/html/en/installation/}}
 % in the obviously-named section ``Make \ST known to \TeX''. Here's a
 % brief summary of how to do that:
 %
@@ -358,7 +358,7 @@ suggestions.
 % modules synchronized. Every copy of Sage since version 4.3.2 comes
 % with a copy of |sagetex.sty| that is matched up to Sage's baked-in \ST
 % support, so you can always use that. See the
-% \href{http://sagemath.org/doc/installation/}{\ST section of the Sage
+% \href{http://doc.sagemath.org/html/en/installation/}{\ST section of the Sage
 %   installation guide}.
 %
 % \subsection{Using \TeX Shop}


### PR DESCRIPTION
The location of SageMath documentation has changed. I've updated the URLs for you. One of the URLs pointing to a bad location was also fixed.

This will address Trac ticket [21450](https://trac.sagemath.org/ticket/21450).
