### PR TITLE
docstrip batch file: compliance to TDS

### DIFF
--- a/sagetex.ins
+++ b/sagetex.ins
@@ -44,6 +44,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 \generate{\file{sagetex.sty}{\from{sagetex.dtx}{latex}
                              \from{py-and-sty.dtx}{latex}}}
 
+
+\usedir{PYTHONLIBDIR}
+
 % Define a new preamble with #'s as comment characters for the Python
 % files. I hate copying the same text, but defining a "\boilerplate"
 % macro requires me to manually do \MetaPrefix\space and ^^J everywhere
@@ -80,6 +83,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 \generate{\file{sagetex.py}{\from{sagetex.dtx}{python}
                             \from{py-and-sty.dtx}{python}}}
 \generate{\file{sagetexparse.py}{\from{scripts.dtx}{parsermod}}}
+
+
+\usedir{scripts/sagetex}
 
 % Now define a new preamble with the shebang line at the top.
 


### PR DESCRIPTION
Attempt to render the DocStrip batch file `sagetex.ins` more compliant with the [TeX Directory Structure scheme](http://tug.ctan.org/tds/tds.html). Note that the *label* PYTHONLIBDIR has to be Declare[Dir[\*]]-ed in the DocStrip configuration file `docstrip.cfg`; on Linux system, the minimal following `docstrip.cfg` might do the trick:
 ```
\def\WriteToDir{./}
\BaseDirectory{/usr/share/texmf}
\UseTDS
\DeclareDir*{PYTHONLIBDIR}{/usr/lib/python/dist-packages}
\maxfiles{32}
\maxoutfiles{8}
\showprogress
```
 For further details, you want to peruse [''The DocStrip program'' guide](https://www.ctan.org/pkg/docstrip).