### PR TITLE
Fix sagetex.dtx refs to install guide

### DIFF
--- a/sagetex.dtx
+++ b/sagetex.dtx
@@ -296,8 +296,8 @@ suggestions.
 % version of \ST to guarantee that everything works properly. As of Sage
 % version 4.3.1, \ST comes included with Sage, so you only need to make
 % \texttt{sagetex.sty}, the \LTX package, known to \TeX. Full details of
-% this are in the Sage Installation guide at
-% \href{http://doc.sagemath.org/html/en/installation/}{\texttt{doc.sagemath.org/html/en/installation/}}
+% this are in the Sage tutorial at
+% \href{http://doc.sagemath.org/html/en/tutorial/sagetex.html}{\texttt{doc.sagemath.org/html/en/tutorial/sagetex.html}}
 % in the obviously-named section ``Make \ST known to \TeX''. Here's a
 % brief summary of how to do that:
 %
@@ -358,8 +358,8 @@ suggestions.
 % modules synchronized. Every copy of Sage since version 4.3.2 comes
 % with a copy of |sagetex.sty| that is matched up to Sage's baked-in \ST
 % support, so you can always use that. See the
-% \href{http://doc.sagemath.org/html/en/installation/}{\ST section of the Sage
-%   installation guide}.
+% \href{http://doc.sagemath.org/html/en/tutorial/sagetex.html}{\ST section of the Sage
+%   tutorial}.
 %
 % \subsection{Using \TeX Shop}
 % \label{sec:using-texshop}


### PR DESCRIPTION
SageTeX references in the documentation are now only in the tutorial.  This PR is designed to fix the ones in the `.dtx` file which generates lots of stuff; please make sure it builds correctly and the links work before merging!!!