### PR TITLE
issue #30: deal with utf8 text in Sage blocks in LaTeX files.

### DIFF
--- a/py-and-sty.dtx
+++ b/py-and-sty.dtx
@@ -859,6 +859,7 @@ again}}
 pyversion = ' '.join(__version__.strip('[').split()[0:2])
 from sage.misc.latex import latex
 from sage.repl.preparse import preparse
+from six import PY3
 import sys
 import os
 import os.path
@@ -1532,7 +1533,10 @@ SAGE_ROOT/local/share/doc/sagetex.""")
                               "print('SageT",
                               "_st_.current_tex_line",
                               " _st_.current_tex_line")):
-          m.update(bytearray(line,'utf8'))
+          if PY3:
+              m.update(bytearray(line,'utf8'))
+          else:
+              m.update(bytearray(line))
 %    \end{macrocode}
 % (The |current_tex_line| thing appears twice because it may appear
 % indented one space or not, depending on whether it's used before


### PR DESCRIPTION
See #30.

I've tested with both Python 2 and 3. Is this the best way to do this? Unicode and Python 2 vs. 3 confuse me. See https://trac.sagemath.org/ticket/27598#comment:1 for a related comment.