### PR TITLE
undo wrong indentation

### DIFF
--- a/scripts.dtx
+++ b/scripts.dtx
@@ -72,7 +72,7 @@ if not uses_sagetex:
 
 # if something goes wrong, assume we need to run Sage
 run_sage = True
-        ignore = r"^( _st_.goboom|print('SageT| ?_st_.current_tex_line))"
+ignore = r"^( _st_.goboom|print('SageT| ?_st_.current_tex_line))"
 
 try:
     with open(src + '.sagetex.sage', 'r') as sagef:


### PR DESCRIPTION
#33 notes that when fixing a missing paren we introduced a spurious indentation.