### PR TITLE
Improve commented_out check

### DIFF
--- a/scripts.dtx
+++ b/scripts.dtx
@@ -62,7 +62,7 @@ uses_sagetex = False
 # if it doesn't use sagetex, obviously running sage is unnecessary
 with open(src + '.tex') as texf:
     for line in texf:
-        if re.search(usepackage, line.split('%')[0]):
+        if re.search(usepackage, line.replace(r'\%', '').split('%')[0]):
             uses_sagetex = True
             break
 

--- a/scripts.dtx
+++ b/scripts.dtx
@@ -56,14 +56,13 @@ if sys.argv[1].endswith('.sagetex.sage'):
 else:
     src = os.path.splitext(sys.argv[1])[0]
 
-commented_out = r'^\s*%'
 usepackage = r'\usepackage(\[.*\])?{sagetex}'
 uses_sagetex = False
 
 # if it doesn't use sagetex, obviously running sage is unnecessary
 with open(src + '.tex') as texf:
     for line in texf:
-        if not re.search(commented_out, line) and re.search(usepackage, line):
+        if re.search(usepackage, line.split('%')[0]):
             uses_sagetex = True
             break
 


### PR DESCRIPTION
Improve the test if '\usepackage{sagetex}' is commented out in the LaTeX source file. See #33.