### PR TITLE
Trivial fix in example.tex for Python3

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -487,7 +487,7 @@ will evaluate functions and write the results into a file:
       for t in tvals:
           try:
               lines.append('{0} {1}  i'.format(fmt(x(t)), fmt(y(t))))
-          except ValueError, ZeroDivisonError:
+          except (ValueError, ZeroDivisonError):
               pass
       with open(fn, 'w') as f:
           f.write('\n'.join(lines) + '\n')


### PR DESCRIPTION
This trivial patch replaces
```
          except ValueError, ZeroDivisonError:
```
with
```
          except (ValueError, ZeroDivisonError):
```
In the source code for a `gnuplot`-generated figure in `example.tex`, which allows its compilation by Python3. The modified `example.tex` also compiles with a Python2-based Sage.

HTH,
