### PR TITLE
Fix link to pgf manual in documentation

### DIFF
--- a/sagetex.dtx
+++ b/sagetex.dtx
@@ -261,7 +261,7 @@ suggestions.
 % |sage.plot.plot?| and look for |ticks| and |tick_formatter|.)
 %
 % Till Tantau has some good commentary on the use of graphics in the
-% \href{http://www.ctan.org/tex-archive/help/Catalogue/entries/pgf.html}{``Guidelines
+% \href{https://pgf-tikz.github.io/pgf/pgfmanual.pdf}{``Guidelines
 %   on Graphics'' section of the \textsc{pgf} manual} (chapter 7 of the
 % manual for version 2.10). You should always give careful thought and
 % attention to creating graphics for your document; I have in mind that

--- a/sagetex.dtx
+++ b/sagetex.dtx
@@ -263,7 +263,7 @@ suggestions.
 % Till Tantau has some good commentary on the use of graphics in the
 % \href{https://pgf-tikz.github.io/pgf/pgfmanual.pdf}{``Guidelines
 %   on Graphics'' section of the \textsc{pgf} manual} (chapter 7 of the
-% manual for version 2.10). You should always give careful thought and
+% manual for version 3.1.9). You should always give careful thought and
 % attention to creating graphics for your document; I have in mind that
 % a good workflow for using \ST for plotting is something like this:
 %


### PR DESCRIPTION
The link http://www.ctan.org/tex-archive/help/Catalogue/entries/pgf.html does not work. This pull request replaces it by:
https://pgf-tikz.github.io/pgf/pgfmanual.pdf