### PR TITLE
Improve typesetting of code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ the SAGE_ROOT/... directory mentioned above.
 If you want to extract any of SageTeX's files from the .dtx sources, you
 can do
 
-  0. Run `latex sagetex.ins'
+  0. Run `latex sagetex.ins`
 
 To regenerate the documentation, do
 
-  1. Run `latex sagetex.dtx'
-  2. Run `sage sagetex.sage'
+  1. Run `latex sagetex.dtx`
+  2. Run `sage sagetex.sage`
   3. Run the indexing commands that the .ins file told you about.
-  4. Run `latex sagetex.dtx' again.
+  4. Run `latex sagetex.dtx` again.
 
 You can skip step 3 if you don't care about the index. You will need the
 pgf and tikz packages installed to typeset the figures.


### PR DESCRIPTION
In README.md, commands are started with the symbol \` and ended with the symbol '. Therefore, the code is not typeset correctly. 
This pull request uses the symbol \` at the start **and** at the end of those commands to typeset them correctly.