### PR TITLE
Fix a duplicate word in the documentation

### DIFF
--- a/sagetex.dtx
+++ b/sagetex.dtx
@@ -481,8 +481,7 @@ suggestions.
 % |15 & 22|\\
 % |\end{array}\right)|
 % \end{quote}
-% in your document---that \LTX code is exactly exactly what you get
-% from doing
+% in your document---that \LTX code is exactly what you get from doing
 % \begin{center}
 % |latex(matrix([[1, 2], [3,4]])^2)|
 % \end{center}


### PR DESCRIPTION
In section 3.1 (page 6) of the documentation, the word "exactly" is duplicated.

This PR fixes this.